### PR TITLE
Fix FlutterVpn.onStateChanged in iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,16 +1,16 @@
-/**
- * Copyright (C) 2018 Jason C.H
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- */
+///
+/// Copyright (C) 2018 Jason C.H
+///
+/// This library is free software; you can redistribute it and/or
+/// modify it under the terms of the GNU Lesser General Public
+/// License as published by the Free Software Foundation; either
+/// version 2.1 of the License, or (at your option) any later version.
+///
+/// This library is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+/// Lesser General Public License for more details.
+///
 
 import 'package:flutter/material.dart';
 import 'package:flutter_vpn/flutter_vpn.dart';

--- a/ios/Classes/SwiftFlutterVpnPlugin.swift
+++ b/ios/Classes/SwiftFlutterVpnPlugin.swift
@@ -19,7 +19,7 @@ import UIKit
 public class SwiftFlutterVpnPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_vpn", binaryMessenger: registrar.messenger())
-    let stateChannel = FlutterEventChannel(name: "flutter_vpn_state", binaryMessenger: registrar.messenger())
+    let stateChannel = FlutterEventChannel(name: "flutter_vpn_states", binaryMessenger: registrar.messenger())
     
     let instance = SwiftFlutterVpnPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)

--- a/lib/flutter_vpn.dart
+++ b/lib/flutter_vpn.dart
@@ -1,16 +1,16 @@
-/**
- * Copyright (C) 2018 Jason C.H
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- */
+///
+/// Copyright (C) 2018 Jason C.H
+///
+/// This library is free software; you can redistribute it and/or
+/// modify it under the terms of the GNU Lesser General Public
+/// License as published by the Free Software Foundation; either
+/// version 2.1 of the License, or (at your option) any later version.
+///
+/// This library is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+/// Lesser General Public License for more details.
+///
 
 import 'dart:io';
 


### PR DESCRIPTION
- Fixes a typo in the channel name for FlutterVpn.onStateChanged on iOS side.
- Fixes doc comments written in /// instead of /* */ (this should increase the pub points by 10)